### PR TITLE
Ensure working auth

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
         "@radix-ui/react-dropdown-menu": "2.1.14",
         "@radix-ui/react-slot": "1.2.2",
         "@ronin/better-auth": "1.0.0",
-        "@ronin/blade": "0.5.4-hono-experimental-365",
+        "@ronin/blade": "0.6.0",
         "@types/react": "19.1.2",
         "add": "2.0.6",
         "class-variance-authority": "0.7.1",
@@ -228,7 +228,7 @@
 
     "@ronin/better-auth": ["@ronin/better-auth@1.0.0", "", { "peerDependencies": { "better-auth": ">=1.2.5", "ronin": ">=6.4.16" } }, "sha512-XxaQkVSs4xzb9cmPQSOPDODsjczBZyQvG1srYbiabqYmAgtcDDIg9DZwdqb79g/xOGJuJ3LugSQH5y+AYlG7AA=="],
 
-    "@ronin/blade": ["@ronin/blade@0.5.4-hono-experimental-365", "", { "dependencies": { "@tailwindcss/node": "4.1.6", "@tailwindcss/oxide": "4.1.6" }, "bin": { "blade": "dist/private/shell/index.js" } }, "sha512-QfL5BkM3B5nuUKgoNiY5foKRyh4cAdDcdq5knkXJnkiRDdr340pOhC9bB3LDXXhOlQHY1ycbaSs2VlK3lKnCMA=="],
+    "@ronin/blade": ["@ronin/blade@0.6.0", "", { "dependencies": { "@tailwindcss/node": "4.1.6", "@tailwindcss/oxide": "4.1.6" }, "bin": { "blade": "dist/private/shell/index.js" } }, "sha512-cSggNvsj4WIzcNfXFJRGOVeBUNO3beurj0IiZjqHNuJZxEyMP3A3rHWLyd1WxXWLsfMZPBSaAXIFyE1QhP+KFA=="],
 
     "@ronin/cli": ["@ronin/cli@0.3.3", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "@ronin/engine": "0.1.23", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" } }, "sha512-rbwi+qboAjOeWguARWzlgtclS0TACQtGxqJhJpSeE/1ickzxsQCrfxXpaFPa1Pfq6u3upiVz5xaT0d5VnC3eZg=="],
 

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,6 +1,6 @@
 import { betterAuth } from "better-auth"
 import { ronin } from "@ronin/better-auth"
-import { createSyntaxFactory } from 'ronin';
+import createSyntaxFactory from 'ronin';
 
 const client = createSyntaxFactory({
   token: process.env.BLADE_APP_TOKEN,

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,8 +1,13 @@
 import { betterAuth } from "better-auth"
 import { ronin } from "@ronin/better-auth"
+import { createSyntaxFactory } from 'ronin';
+
+const client = createSyntaxFactory({
+  token: process.env.BLADE_APP_TOKEN,
+})
 
 export const auth = betterAuth({
-  database: ronin(),
+  database: ronin(client),
 })
 
 export type AuthType = {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@radix-ui/react-dropdown-menu": "2.1.14",
     "@radix-ui/react-slot": "1.2.2",
     "@ronin/better-auth": "1.0.0",
-    "@ronin/blade": "0.5.4-hono-experimental-365",
+    "@ronin/blade": "0.6.0",
     "@types/react": "19.1.2",
     "add": "2.0.6",
     "class-variance-authority": "0.7.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,8 +15,7 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noPropertyAccessFromIndexSignature": true
+    "noUnusedParameters": true
   },
   "include": [
     ".ronin/*.d.ts",


### PR DESCRIPTION
This change was missing from https://github.com/solbond/solbond/pull/1 and ensures that Better Auth can be used for authentication.